### PR TITLE
Fix warnings generated by gcc when compiling with optimizations

### DIFF
--- a/bench/kernel/minver/minver.c
+++ b/bench/kernel/minver/minver.c
@@ -104,7 +104,7 @@ int minver_minver( int side, double eps )
 
   int work[ 500 ], i, j, k, iw;
   int r = 0;
-  double w, wmax, pivot, api, w1;
+  double w = 0, wmax, pivot, api, w1;
 
   if ( side < 2 || side > 500 || eps <= 0.0 )
     return ( 999 );

--- a/bench/sequential/dijkstra/dijkstra.c
+++ b/bench/sequential/dijkstra/dijkstra.c
@@ -132,8 +132,8 @@ int dijkstra_qcount( void )
 int dijkstra_find( int chStart, int chEnd )
 {
   int ch;
-  int prev, node;
-  int cost, dist;
+  int prev, node = 0;
+  int cost, dist = 0;
   int i;
 
   _Pragma( "loopbound min 100 max 100" )

--- a/bench/sequential/mpeg2/mpeg2.c
+++ b/bench/sequential/mpeg2/mpeg2.c
@@ -12447,7 +12447,7 @@ void mpeg2_dpframe_estimate( unsigned char *ref, unsigned char *mb, int i,
 {
   int pref, ppred, delta_x, delta_y;
   int is, js, it, jt, ib, jb, it0, jt0, ib0, jb0;
-  int imins, jmins, imint, jmint, iminb, jminb, imindmv, jmindmv;
+  int imins = 0, jmins = 0, imint = 0, jmint = 0, iminb = 0, jminb = 0, imindmv = 0, jmindmv = 0;
   int vmc, local_dist;
 
 
@@ -12604,7 +12604,7 @@ void mpeg2_dpfield_estimate( unsigned char *topref, unsigned char *botref,
 {
   unsigned char *sameref, *oppref;
   int io0, jo0, io, jo, delta_x, delta_y, mvxs, mvys, mvxo0, mvyo0;
-  int imino, jmino, imindmv, jmindmv, vmc_dp, local_dist;
+  int imino = 0, jmino = 0, imindmv = 0, jmindmv = 0, vmc_dp = 0, local_dist = 0;
 
 
   /* Calculate Dual Prime distortions for 9 delta candidates */


### PR DESCRIPTION
When compiling with -O2 on a sufficiently new gcc (7.4.0 in my case) the benchmark generates a lot of compiler errors. See below for output of compiler.

The biggest change is lms.c, which contained undefined behaviour(UB) by accessing lms_input out of bounds. The proposed fix is to calculate lms_input[0] and [1] outside of the loop and fix the off-by-one error, rather than adding an if statement inside a for loop.

```
Entering app/ 
Checking lift/ ...passed. 
Checking powerwindow/ ...passed. 
Leaving app/ 

Entering kernel/ 
Checking binarysearch/ ...passed. 
Checking bitcount/ ...passed. 
Checking bitonic/ ...passed. 
Checking bsort/ ...passed. 
Checking complex_updates/ ...passed. 
Checking cosf/ ...passed. 
Checking countnegative/ ...passed. 
Checking cubic/ ...passed. 
Checking deg2rad/ ...passed. 
Checking fac/ ...passed. 
Checking fft/ ...passed. 
Checking filterbank/ ...passed. 
Checking fir2dim/ ...passed. 
Checking iir/ ...passed. 
Checking insertsort/ ...passed. 
Checking isqrt/ ...passed. 
Checking jfdctint/ ...passed. 
Checking lms/ ...lms.c: In function ‘lms_init’:
lms.c:98:24: error: iteration 100 invokes undefined behavior [-Werror=aggressive-loop-optimizations]
     lms_input[ k + 2 ] = lms_sinus( k + 1 ) + noise * v1;
     ~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
lms.c:82:3: note: within this loop
   for ( k = 0 ; k < N ; k += 2 ) {
   ^~~
cc1: all warnings being treated as errors
failed (compiled with errors/warnings). 
Checking ludcmp/ ...passed. 
Checking matrix1/ ...passed. 
Checking md5/ ...passed. 
Checking minver/ ...minver.c: In function ‘minver_minver’:
minver.c:134:10: error: ‘w’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
       w1 = -w;
       ~~~^~~~
cc1: all warnings being treated as errors
failed (compiled with errors/warnings). 
Checking pm/ ...passed. 
Checking prime/ ...passed. 
Checking quicksort/ ...passed. 
Checking rad2deg/ ...passed. 
Checking recursion/ ...passed. 
Checking sha/ ...passed. 
Checking st/ ...passed. 
Leaving kernel/ 

Entering parallel/ 
Checking DEBIE/ ...gcc: error: *.c: No such file or directory
gcc: fatal error: no input files
compilation terminated.
failed (compiled with errors/warnings). 
Checking PapaBench/ ...gcc: error: *.c: No such file or directory
gcc: fatal error: no input files
compilation terminated.
failed (compiled with errors/warnings). 
Checking rosace/ ...gcc: error: *.c: No such file or directory
gcc: fatal error: no input files
compilation terminated.
failed (compiled with errors/warnings). 
Leaving parallel/ 

Entering sequential/ 
Checking adpcm_dec/ ...passed. 
Checking adpcm_enc/ ...passed. 
Checking ammunition/ ...passed. 
Checking anagram/ ...passed. 
Checking audiobeam/ ...passed. 
Checking cjpeg_transupp/ ...passed. 
Checking cjpeg_wrbmp/ ...passed. 
Checking dijkstra/ ...dijkstra.c: In function ‘dijkstra_find’:
dijkstra.c:136:13: error: ‘dist’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   int cost, dist;
             ^~~~
dijkstra.c:164:18: error: ‘node’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
             if ( dijkstra_enqueue ( i, dist + cost, node ) == OUT_OF_MEMORY )
                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1: all warnings being treated as errors
failed (compiled with errors/warnings). 
Checking epic/ ...passed. 
Checking fmref/ ...passed. 
Checking g723_enc/ ...passed. 
Checking gsm_dec/ ...passed. 
Checking gsm_enc/ ...passed. 
Checking h264_dec/ ...passed. 
Checking huff_dec/ ...passed. 
Checking huff_enc/ ...passed. 
Checking mpeg2/ ...mpeg2.c: In function ‘mpeg2_dpframe_estimate’:
mpeg2.c:12595:13: error: ‘jmindmv’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   *jmindmvp = jmindmv;
   ~~~~~~~~~~^~~~~~~~~
mpeg2.c:12594:13: error: ‘imindmv’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   *imindmvp = imindmv;
   ~~~~~~~~~~^~~~~~~~~
mpeg2.c:12584:5: error: ‘jminb’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     mpeg2_bdist1(
     ^~~~~~~~~~~~~
       ref + mpeg2_width + ( imins >> 1 )
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       + ( mpeg2_width << 1 ) * ( jmins >> 1 ),
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       ref + ( iminb >> 1 ) + ( mpeg2_width << 1 ) * ( jminb >> 1 ),
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       mb + mpeg2_width, mpeg2_width << 1, imins & 1, jmins & 1, iminb & 1,
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       jminb & 1, 8 );
       ~~~~~~~~~~~~~~
mpeg2.c:12584:5: error: ‘iminb’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
mpeg2.c:12578:5: error: ‘jmint’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     mpeg2_bdist1(
     ^~~~~~~~~~~~~
       ref + ( imins >> 1 ) + ( mpeg2_width << 1 ) * ( jmins >> 1 ),
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       ref + mpeg2_width + ( imint >> 1 )
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       + ( mpeg2_width << 1 ) * ( jmint >> 1 ),
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       mb, mpeg2_width << 1, imins & 1, jmins & 1, imint & 1, jmint & 1, 8 );
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
mpeg2.c:12578:5: error: ‘imint’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
mpeg2.c:12578:5: error: ‘jmins’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
mpeg2.c:12578:5: error: ‘imins’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
mpeg2.c: In function ‘mpeg2_dpfield_estimate’:
mpeg2.c:12690:13: error: ‘jmindmv’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   *jmindmvp = jmindmv;
   ~~~~~~~~~~^~~~~~~~~
mpeg2.c:12689:13: error: ‘imindmv’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
   *imindmvp = imindmv;
   ~~~~~~~~~~^~~~~~~~~
mpeg2.c:12681:5: error: ‘jmino’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
     mpeg2_bdist1(
     ^~~~~~~~~~~~~
       sameref + ( imins >> 1 ) + mpeg2_width2 * ( jmins >> 1 ),
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       oppref + ( imino >> 1 ) + mpeg2_width2 * ( jmino >> 1 ),
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       mb,             /* current mb location */
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       mpeg2_width2,         /* adjacent line distance */
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       imins & 1, jmins & 1, imino & 1, jmino & 1, /* half-pel flags */
       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
       16 );           /* block height */
       ~~~~
mpeg2.c:12681:5: error: ‘imino’ may be used uninitialized in this function [-Werror=maybe-uninitialized]
cc1: all warnings being treated as errors
failed (compiled with errors/warnings). 
Checking ndes/ ...passed. 
Checking petrinet/ ...passed. 
Checking rijndael_dec/ ...passed. 
Checking rijndael_enc/ ...passed. 
Checking statemate/ ...passed. 
Checking susan/ ...passed. 
Leaving sequential/ 

Entering test/ 
Checking cover/ ...passed. 
Checking duff/ ...passed. 
Checking test3/ ...passed. 
Leaving test/ 

PASS: 53, FAIL_COMP: 7, FAIL_EXEC: 0
```