### PR TITLE
Remove stdlib-printfs

### DIFF
--- a/bench/kernel/fac/fac.c
+++ b/bench/kernel/fac/fac.c
@@ -23,13 +23,11 @@
 /*
   Forward declaration of functions
 */
-int printf(const char * restrict format, ... );
 int fac_fac( int n );
 void fac_init();
 int fac_return();
 void fac_main();
 int main( void );
-int counter1 = 0;
 /*
   Declaration of global variables
 */
@@ -64,7 +62,6 @@ int fac_return()
 
 int fac_fac ( int n )
 {
-    counter1++;
   if ( n == 0 )
     return 1;
   else
@@ -87,7 +84,6 @@ void _Pragma( "entrypoint" ) fac_main ()
     fac_s += fac_fac ( i );
     _Pragma( "flowrestriction 1*fac_fac <= 6*recursivecall" )
   }
-  printf("%d\n", counter1);
 }
 
 

--- a/bench/sequential/anagram/anagram.c
+++ b/bench/sequential/anagram/anagram.c
@@ -156,13 +156,11 @@
    If you increase it beyond 4, you'll have to add a few more loop unrolling
    steps to FindAnagram.
 */
-int printf(const char * restrict format, ... );
 #include "anagram_ctype.h"
 #include "anagram_stdlib.h"
 #include "anagram_strings.h"
 
 #include "anagram_compare.h"
-int counter1 = 0;
 
 /*
   Defines
@@ -550,7 +548,6 @@ void anagram_DumpWords( void )
 void anagram_FindAnagram( anagram_Quad *pqMask, anagram_PPWord ppwStart,
                           int iLetter )
 {
-    counter1++;
   anagram_Quad aqNext[ anagram_MAX_QUADS ];
   register anagram_PWord pw;
   anagram_Quad qMask;
@@ -647,7 +644,6 @@ void _Pragma( "entrypoint" ) anagram_main( void )
     anagram_FindAnagram( anagram_aqMainMask, anagram_apwCand, 0 );
     _Pragma( "flowrestriction 1*anagram_FindAnagram <= 51*call_find" )
   }
-  printf("1: %d\n", counter1);
 }
 
 

--- a/bench/sequential/anagram/anagram_stdlib.c
+++ b/bench/sequential/anagram/anagram_stdlib.c
@@ -18,7 +18,6 @@
   License: See anagram.c
 
 */
-int counter2 = 0;
 #include "anagram_stdlib.h"
 #include "anagram_strings.h"
 
@@ -26,7 +25,6 @@ int counter2 = 0;
 /* This function is included here because the WCC does not */
 /* support function pointers */
 #include "anagram_compare.h"
-int printf(const char * restrict format, ... );
 
 void anagram_swapi( char *ii, char *ij, unsigned long es )
 {
@@ -74,7 +72,6 @@ void anagram_qsorts( char *a, unsigned long n, unsigned long es )
   unsigned long j;
   char *pi, *pj, *pn;
   volatile unsigned int flowfactdummy = 0;
-        counter2++;
   _Pragma( "loopbound min 0 max 3" )
   while ( n > 1 ) {
     if ( n > 10 )
@@ -121,7 +118,6 @@ void anagram_qsort( void *va, unsigned long n, unsigned long es )
   _Pragma( "marker call_qsorts" )
   anagram_qsorts( ( char * )va, n, es );
   _Pragma( "flowrestriction 1*anagram_qsorts <= 17*call_qsorts" )
-  printf("2: %d\n", counter2);
 }
 
 

--- a/bench/sequential/huff_enc/huff_enc.c
+++ b/bench/sequential/huff_enc/huff_enc.c
@@ -48,8 +48,6 @@
 /*
   Declaration of types
 */
-int printf(const char * restrict format, ... );
-int counter1 = 0;
 typedef struct huff_enc_s_tree {
   unsigned int byte; /* A byte has to be coded as an unsigned integer to
                         allow a node to have a value over 255 */
@@ -366,8 +364,6 @@ void huff_enc_qsort( char *a, unsigned long n, unsigned long es )       //wird i
   unsigned long j;
   char *pi, *pj, *pn;
   unsigned int flowfactdummy = 0;
-  counter1++;
-  printf("%d\n", counter1);
   _Pragma( "loopbound min 0 max 7" )
   while ( n > 1 ) {
     if ( n > 10 )

--- a/bench/sequential/susan/susan.c
+++ b/bench/sequential/susan/susan.c
@@ -272,7 +272,6 @@
 #include "wcclibm.h"
 #include "wccfile.h"
 #include "wccmalloc.h"
-int printf(const char * restrict format, ... );
 #define EXP_A 184
 #define EXP_C 16249
 
@@ -676,7 +675,6 @@ void susan_smoothing( int three_by_three, uchar *in, float dt,
   tmp_image = ( uchar * )susan_wccmalloc( ( x_size + mask_size * 2 ) *
                                           ( y_size + mask_size * 2 ) );
   susan_enlarge( &in, tmp_image, &x_size, &y_size, mask_size );
-    printf("x_size: %d\n", x_size);
   if ( three_by_three == 0 ) {
     /* large Gaussian masks */
     /* {{{ setup distance lut */


### PR DESCRIPTION
ffdc3f5 introduced some counter variables as well as printf statements
into the testcases fac, anagram, huff_enc and susan.
However, neither of those testcases actually provide a printf
implementation themselves, so instead the libc variant was linked and
used. This happend within the designated analysis entrypoints, and was
thus part of the benchmark. This breaks those benchmarks for
sourcelevel WCET-analyzers, so I've removed those calls there.

Note: I've only tested the `kernel` and `sequential` benchmarks, it might
 be that similar things might still be found within the `app` or `parallel`
benchmarks as well.

Please let me know in case you have any further questions.