### PR TITLE
cast, so fraction works properly on ARM

### DIFF
--- a/bench/kernel/fft/fft.c
+++ b/bench/kernel/fft/fft.c
@@ -241,7 +241,7 @@ int fft_convert( float value )
     rnd_val = 1;
     if ( frac < 0.5f ) rnd_val = 0;
   }
-  int_val = man + rnd_val;
+  int_val = (long)man + (long)rnd_val;
 
   pm_val = int_val ;
   return ( ( int ) ( pm_val ) ) ;


### PR DESCRIPTION
The fft benchmark result gives a wrong value on ARM processors (Raspberry Pi 4 64-bit, compiled with aarch64-linux-gnu-gcc) because during the  initialization there is a conversion/cast/overflow error (not sure exactly). The proposed change just explicitly casts into "long" types before adding the "float" and "int" types together. The change is tested and works on x86 compiled with x86_64-linux-gnu-gcc and the Raspberry Pi4 compiled with aarch64-linux-gnu-gcc. I am not sure if this is the best way for other platforms as well or if there is a more generic way, but fixes it for for the Raspberry Pi 4 at least. If there is a better solution reject this pull request and let me know how that could possibly look like.