### PR TITLE
Fix #28 anagram oob

### DIFF
--- a/bench/sequential/anagram/anagram.c
+++ b/bench/sequential/anagram/anagram.c
@@ -302,7 +302,7 @@ void anagram_ReadDict( void )
     _Pragma( "loopbound min 1 max 5" )
     while ( anagram_dictionary[ i ][ strlen ] != 0 )
       strlen ++;
-    len += strlen + 2;
+    len += strlen + 3;
   }
 
   pchBase = anagram_pchDictionary = ( char * )anagram_malloc( len );

--- a/bench/sequential/anagram/anagram.c
+++ b/bench/sequential/anagram/anagram.c
@@ -305,6 +305,7 @@ void anagram_ReadDict( void )
     len += strlen + 3;
   }
 
+  len ++;
   pchBase = anagram_pchDictionary = ( char * )anagram_malloc( len );
 
   _Pragma( "loopbound min 2279 max 2279" )

--- a/bench/sequential/anagram/anagram_stdlib.c
+++ b/bench/sequential/anagram/anagram_stdlib.c
@@ -122,7 +122,7 @@ void anagram_qsort( void *va, unsigned long n, unsigned long es )
 
 
 /* This must be redefined for each new benchmark */
-#define ANAGRAM_HEAP_SIZE 18000
+#define ANAGRAM_HEAP_SIZE 21000
 
 static char anagram_simulated_heap[ANAGRAM_HEAP_SIZE];
 static unsigned int anagram_freeHeapPos;


### PR DESCRIPTION
These changes fix the memory allocation for the `sequential/anagram` word dictionary to account for the word terminator. The heap capacity has been accordingly increased. 

The new heap capacity (and the small fix) have been been verified empirically:
- the allocated heap should not exceed its capacity
- there is no corruption of the word dictionary structure resulting in an infinite loop

Fixes #28 