### PR TITLE
Fix undefined behavior in powerwindow

### DIFF
--- a/bench/app/powerwindow/powerwindow_PW_Control_DRV.c
+++ b/bench/app/powerwindow/powerwindow_PW_Control_DRV.c
@@ -134,15 +134,15 @@ void powerwindow_PW_Control_DRV_initialize( void )
   /* Registration code */
 
   /* states (dwork) */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_DR_DWork, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_DR_DWork, 0,
                    sizeof( powerwindow_D_Work_powerwindow_PW_Control_D ) );
 
   /* external inputs */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_DRV_U, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_DRV_U, 0,
                    sizeof( powerwindow_ExternalInputs_powerwindow_PW_C ) );
 
   /* external outputs */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_DRV_Y, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_DRV_Y, 0,
                    sizeof( powerwindow_ExternalOutputs_powerwindow_PW_ ) );
 
   /* Model Initialize fcn for ModelReference Block: '<S2>/Debounce_Down_DRV' */

--- a/bench/app/powerwindow/powerwindow_PW_Control_PSG_BackL.c
+++ b/bench/app/powerwindow/powerwindow_PW_Control_PSG_BackL.c
@@ -102,15 +102,15 @@ void powerwindow_PW_Control_PSG_BackL_initialize( void )
       ( NULL ) );
 
   /* states (dwork) */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_BackL_DWork, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_BackL_DWork, 0,
                    sizeof( powerwindow_D_Work_PW_Control_PSG_BackL ) );
 
   /* external inputs */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_BackL_U, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_BackL_U, 0,
                    sizeof( powerwindow_ExternalInputs_PW_Control_PSG_BackL ) );
 
   /* external outputs */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_BackL_Y, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_BackL_Y, 0,
                    sizeof( powerwindow_ExternalOutputs_PW_Control_PSG_BackL ) );
 
   /* Model Initialize fcn for ModelReference Block: '<S1>/ControlEx_PSG_BackL' */

--- a/bench/app/powerwindow/powerwindow_PW_Control_PSG_BackR.c
+++ b/bench/app/powerwindow/powerwindow_PW_Control_PSG_BackR.c
@@ -102,15 +102,15 @@ void powerwindow_PW_Control_PSG_BackR_initialize( void )
       ( NULL ) );
 
   /* states (dwork) */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_BackR_DWork, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_BackR_DWork, 0,
                    sizeof( powerwindow_D_Work_PW_Control_PSG_BackR ) );
 
   /* external inputs */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_BackR_U, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_BackR_U, 0,
                    sizeof( powerwindow_ExternalInputs_PW_Control_PSG_BackR ) );
 
   /* external outputs */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_BackR_Y, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_BackR_Y, 0,
                    sizeof( powerwindow_ExternalOutputs_PW_Control_PSG_BackR ) );
 
   /* Model Initialize fcn for ModelReference Block: '<S1>/ControlEx_PSG_BackR' */

--- a/bench/app/powerwindow/powerwindow_PW_Control_PSG_Front.c
+++ b/bench/app/powerwindow/powerwindow_PW_Control_PSG_Front.c
@@ -103,15 +103,15 @@ void powerwindow_PW_Control_PSG_Front_initialize( void )
       ( NULL ) );
 
   /* states (dwork) */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_Front_DWork, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_Front_DWork, 0,
                    sizeof( powerwindow_D_Work_PW_Control_PSG_Front ) );
 
   /* external inputs */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_Front_U, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_Front_U, 0,
                    sizeof( powerwindow_ExternalInputs_PW_Control_PSG_Front ) );
 
   /* external outputs */
-  ( void ) memset( ( void * )&powerwindow_PW_Control_PSG_Front_Y, 0,
+  ( void ) wcclib_memset( ( void * )&powerwindow_PW_Control_PSG_Front_Y, 0,
                    sizeof( powerwindow_ExternalOutputs_PW_Control_PSG_Front ) );
 
   /* Model Initialize fcn for ModelReference Block: '<S1>/ControlEx_PSG_Front_Front' */

--- a/bench/app/powerwindow/powerwindow_debounce.c
+++ b/bench/app/powerwindow/powerwindow_debounce.c
@@ -85,11 +85,11 @@ void powerwindow_debounce_initialize( const powerwindow_char_T **rt_errorStatus,
   powerwindow_rtmSetErrorStatusPointer( debounce_M, rt_errorStatus );
 
   /* block I/O */
-  ( void ) memset( ( ( void * ) localB ), 0,
+  ( void ) wcclib_memset( ( ( void * ) localB ), 0,
                    sizeof( powerwindow_rtB_debounce_T ) );
 
   /* states (dwork) */
-  ( void ) memset( ( void * )localDW, 0,
+  ( void ) wcclib_memset( ( void * )localDW, 0,
                    sizeof( powerwindow_rtDW_debounce_T ) );
   localZCE->Chart_Trig_ZCE = powerwindow_POS_ZCSIG;
 }

--- a/bench/app/powerwindow/powerwindow_powerwindow_control.c
+++ b/bench/app/powerwindow/powerwindow_powerwindow_control.c
@@ -538,11 +538,11 @@ void powerwindow_powerwindow_control_initialize( const powerwindow_char_T
       rt_errorStatus );
 
   /* block I/O */
-  ( void ) memset( ( ( void * ) localB ), 0,
+  ( void ) wcclib_memset( ( ( void * ) localB ), 0,
                    sizeof( powerwindow_rtB_PowerWindow_control ) );
 
   /* states (dwork) */
-  ( void ) memset( ( void * )localDW, 0,
+  ( void ) wcclib_memset( ( void * )localDW, 0,
                    sizeof( powerwindow_rtDW_PowerWindow_control ) );
   localZCE->stateflowcontrolmodel_Trig_ZCE = powerwindow_UNINITIALIZED_ZCSIG;
 }

--- a/bench/app/powerwindow/wcclib.c
+++ b/bench/app/powerwindow/wcclib.c
@@ -1,7 +1,7 @@
 #include "wcclib.h"
 
 
-void *memset( void *s, int c, size_t n )
+void *wcclib_memset( void *s, int c, size_t n )
 {
   unsigned char *p = s;
 

--- a/bench/app/powerwindow/wcclib.h
+++ b/bench/app/powerwindow/wcclib.h
@@ -9,6 +9,6 @@
 
 #define NULL ( (void *) 0)
 
-void *memset( void *s, int c, size_t n );
+void *wcclib_memset( void *s, int c, size_t n );
 
 #endif // _WCCLIB


### PR DESCRIPTION
`powerwindow` compiled using `gcc *.c -O2 -Wall -Wextra` emits no relevant warnings on aarch64, but the resulting binary crashes.

The reason is that the loop in `memset` is optimized into a call to `memset`, resulting in an infinite recursion and a blown up stack.

In the relevant GCC bug report from 9 years ago it is argued that the behavior is valid: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=56888

> There's already a memcpy function in the standard library, so naming your own function memcpy violates the one-definition-per-function rule. Even if it "worked", naming your own function memcpy would likely break other standard library functions that call the "real" memcpy.

Fixed by renaming `memset` into `wcclib_memset`. Fixes #30 