### PR TITLE
kernel/bitcount now works for both endians

### DIFF
--- a/bench/kernel/bitcount/bitcnt_4.c
+++ b/bench/kernel/bitcount/bitcnt_4.c
@@ -72,8 +72,12 @@ int bitcount_ntbl_bitcnt( unsigned long x )
 
 int bitcount_btbl_bitcnt( unsigned long x )
 {
-
-  int cnt = bitcount_bits[  ( ( char * ) & x )[ 0 ] & 0xFF  ];
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+  int idx = sizeof(x) - 1;
+#else
+  int idx =  0;
+#endif
+  int cnt = bitcount_bits[( ( char * ) & x )[idx] & 0xFF];
 
   if ( 0L != ( x >>= 8 ) )
     cnt += bitcount_btbl_bitcnt( x );


### PR DESCRIPTION
Fixes #12 

The solution uses default GCC/Clang macros so should be portable.
I ran it both using `patmos-clang` and `gcc` and it returned a 0 exit code when executed in both cases (previously, `patmos-clang` would result in an exit code of 1)

Solution inpired by @flopsi's patch in #12.