### PR TITLE
Fix #28 anagram oob v2

### DIFF
--- a/bench/sequential/anagram/anagram.c
+++ b/bench/sequential/anagram/anagram.c
@@ -302,7 +302,7 @@ void anagram_ReadDict( void )
     _Pragma( "loopbound min 1 max 5" )
     while ( anagram_dictionary[ i ][ strlen ] != 0 )
       strlen ++;
-    len += strlen + 2;
+    len += strlen + 3;
   }
 
   pchBase = anagram_pchDictionary = ( char * )anagram_malloc( len );

--- a/bench/sequential/anagram/anagram.c
+++ b/bench/sequential/anagram/anagram.c
@@ -305,6 +305,7 @@ void anagram_ReadDict( void )
     len += strlen + 3;
   }
 
+  len ++;
   pchBase = anagram_pchDictionary = ( char * )anagram_malloc( len );
 
   _Pragma( "loopbound min 2279 max 2279" )

--- a/bench/sequential/anagram/anagram.c
+++ b/bench/sequential/anagram/anagram.c
@@ -342,7 +342,7 @@ void anagram_init( void )
 int anagram_return( void )
 {
   int i;
-  char const *answer = "duke rip amy";
+  char const *answer = "duke yip arm";
 
   _Pragma( "loopbound min 12 max 12" )
   for ( i = 0; i < 12; i++ )

--- a/bench/sequential/anagram/anagram_stdlib.c
+++ b/bench/sequential/anagram/anagram_stdlib.c
@@ -122,7 +122,7 @@ void anagram_qsort( void *va, unsigned long n, unsigned long es )
 
 
 /* This must be redefined for each new benchmark */
-#define ANAGRAM_HEAP_SIZE 18000
+#define ANAGRAM_HEAP_SIZE 21000
 
 static char anagram_simulated_heap[ANAGRAM_HEAP_SIZE];
 static unsigned int anagram_freeHeapPos;


### PR DESCRIPTION
This PR is an improved version of #29 with fixed result comparison in `anagram_return`, so that the benchmark terminates with 0 exit code.

The current anagram implementation does indeed exhibit undefined behavior resulting in an infinite loop, since the length calculation in `anagram_ReadDict` does not account for null-terminators in strings:

https://github.com/tacle/tacle-bench/blob/e747e24f68631a508f6675c925ee3ede8e631d83/bench/sequential/anagram/anagram.c#L303-L305

and the final 0 terminating the dict:

https://github.com/tacle/tacle-bench/blob/e747e24f68631a508f6675c925ee3ede8e631d83/bench/sequential/anagram/anagram.c#L331

As a result, subsequent allocations by `anagram_NewWord` return portions of heap used by the dict, which are overwritten, leading to an incorrect result in `anagram_buffer`.

Benchmark with allocation fix by @Gaudeval yields a different value, leading me to believe the present value of `char const *answer` in `anagram_return` was obtained by running the flawed benchmark and inspecting the computed value.

Fixes #28 