### PR TITLE
Corrected dijkstra loop bounds

### DIFF
--- a/bench/sequential/dijkstra/dijkstra.c
+++ b/bench/sequential/dijkstra/dijkstra.c
@@ -103,8 +103,7 @@ int dijkstra_enqueue( int node, int dist, int prev )
   if ( !last )
     dijkstra_queueHead = newItem;
   else {
-    /* TODO: where does this magic loop bound come from? */
-    _Pragma( "loopbound min 0 max 313" )
+    _Pragma( "loopbound min 0 max 1000" )
     while ( last->next )
       last = last->next;
     last->next = newItem;
@@ -149,9 +148,8 @@ int dijkstra_find( int chStart, int chEnd )
 
     if ( dijkstra_enqueue ( chStart, 0, NONE ) == OUT_OF_MEMORY )
       return OUT_OF_MEMORY;
-
-    /* TODO: where does this magic loop bound come from? */
-    _Pragma( "loopbound min 618 max 928" )
+    
+    _Pragma( "loopbound min 100 max 1000" )
     while ( dijkstra_qcount() > 0 ) {
       dijkstra_dequeue ( &node, &dist, &prev );
       _Pragma( "loopbound min 100 max 100" )


### PR DESCRIPTION
In dijkstra_enqueue, the queue can at worst be full (1000 elements).

In dijkstra_find, all nodes must be looked at at least once (100 nodes). I'm an unsure about the max, though I have observed up to 943. 1000 is my guess.